### PR TITLE
Adds .scss file to import from Sass.

### DIFF
--- a/canonical.scss
+++ b/canonical.scss
@@ -1,0 +1,332 @@
+@charset "UTF-8";
+/*! Canonical.css by Marko Kazhich (marxo.me) */
+/**
+ * Setting box-sizing to border-box initially
+ */
+
+:root {
+  box-sizing: border-box;
+  font: 16px/1.5 sans-serif;
+}
+/**
+ * 1. Inherit border-box on all elements
+ * 2. Aligns inline and inline-block elements to the middle
+ */
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+  /* 1 */
+
+  vertical-align: middle;
+  /* 2 */
+}
+
+body {
+  margin: 0;
+}
+
+// Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
+// Correct `block` display not defined for `main` in IE 11.
+details,
+summary,
+main {
+  display: block;
+}
+
+// Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+progress,
+b,
+i,
+strong,
+em {
+  vertical-align: baseline;
+}
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+/**
+ * 1. Remove the gray background color from active links in IE 10.
+ * 2. Improve readability of focused elements when they are also in an
+ * active/hover state.
+ * 3. Use a pointer cursor for all links even without a href attribute
+ */
+
+a {
+  background-color: transparent;
+  /* 1 */
+
+  &:active, &:hover {
+    outline: 0;
+    /* 2 */
+  }
+  cursor: pointer;
+  /* 3 */
+}
+/**
+ * 1. Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  /* 1 */
+
+  font-weight: bold;
+}
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: .75em;
+}
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+/**
+ * Normalize horizontal rule and keep it lean
+ */
+
+hr {
+  border: 0;
+  height: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: .75em;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.25em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+/**
+ * 1. Correct color not being inherited.
+ *  Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  /* 1 */
+
+  font: inherit;
+  /* 2 */
+
+  margin: 0;
+  /* 3 */
+}
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+/**
+ * 1. Correct inability to style clickable `input` types in iOS.
+ * 2. Improve usability and consistency of cursor style between image-type
+ *  `input` and others.
+ */
+
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  /* 1 */
+
+  cursor: pointer;
+  /* 2 */
+}
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+input[disabled] {
+  cursor: default;
+}
+/**
+ * Reset button styling for disabled buttons in Chrome/Blink/WebKit
+ */
+
+button[disabled],
+input[type=submit][disabled] {
+  -webkit-appearance: textfield;
+}
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  padding: 0;
+}
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+
+  box-sizing: content-box;
+  /* 2 */
+}
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+/* Hide clear button in Internet Explorer 10/11 */
+
+::-ms-clear {
+  display: none;
+}
+/* Hide reveal password button in Internet Explorer 10/11 */
+
+::-ms-reveal {
+  display: none;
+}
+/* Responsive images and other embedded objects */
+
+img,
+object,
+embed {
+  max-width: 100%;
+}
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+/**
+ * 1. Remove default vertical scrollbar in IE 8/9/10/11.
+ * 2. Disable textarea horizontal resize
+ */
+
+textarea {
+  overflow: auto;
+  /* 1 */
+
+  resize: vertical;
+  /* 2 */
+}
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+/**
+ * Adress `video` being streched out of proportion and responsive video
+ */
+
+video {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Since Sass [still](https://github.com/sass/sass/issues/193) won't add support to import `.css` files into `.scss`, I've added a renamed copy of the `.less` file. Also, reindented it with soft tabs because that's more common in Ruby+Sass projects.
